### PR TITLE
AYH-12: Pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,26 +16,41 @@ The AI Feed module, developed by Yale ITS, is designed to create a feed of websi
 This module creates an endpoint of website content at `api/ai/v1/content`. Currently, this feed is limited to published nodes that are accessible to anonymous users. In the future, this may be expanded to include filters and new entity types. The shape of the JSON is as follows:
 
 ```json
-[
-  {
-    "url": "yalesites-yale.edu-node-18",
-    "source": "drupal"
-    "documentType": "node/page",
-    "documentId": 18,
-    "documentTitle": "Resources and Workshops",
-    "documentUrl": "https://yalesites.yale.edu/resource",
-    "documentContent": "...",
-    "metaTags": "",
-    "metaDescription": "",
-    "dateCreated": "2023-10-12T16:09:21+00:00",
-    "dateModified": "2023-11-30T16:11:18+00:00",
-    "dateProcessed": "2024-01-23T16:05:38+00:00",
+{
+  "data": [
+    {
+      "url": "yalesites-yale.edu-node-18",
+      "source": "drupal",
+      "documentType": "node/page",
+      "documentId": 18,
+      "documentTitle": "Resources and Workshops",
+      "documentUrl": "https://yalesites.yale.edu/resource",
+      "documentContent": "...",
+      "metaTags": "",
+      "metaDescription": "",
+      "dateCreated": "2023-10-12T16:09:21+00:00",
+      "dateModified": "2023-11-30T16:11:18+00:00",
+      "dateProcessed": "2024-01-23T16:05:38+00:00",
+    },
+    { ... },
+  ],
+  "links": {
+    "first": "https://yalesites.yale.edu/api/ai/v1/content?page=1",
+    "prev": "https://yalesites.yale.edu/api/ai/v1/content?page=1",
+    "self": "https://yalesites.yale.edu/api/ai/v1/content?page=2",
+    "next": "",
+    "last": "https://yalesites.yale.edu/api/ai/v1/content?page=2"
   },
-  { ... }
-]
+  "totals": {
+    "total_records": 52,
+    "total_pages": 2
+  }
+}
 ```
 
-| Field           | Type    | Description                                |
+## Data Fields
+
+| Data Field      | Type    | Description                                |
 |-----------------|---------|--------------------------------------------|
 | id              | String  | A unique id used by the search index       |
 | documentType    | String  | Follows the pattern entityTypeId/bundle    |
@@ -48,6 +63,36 @@ This module creates an endpoint of website content at `api/ai/v1/content`. Curre
 | dateCreated     | Date    | Created date as ISO 8601                   |
 | dateModified    | Date    | Modified date as ISO 8601                  |
 | dateProcessed   | Date    | When this record was generated as ISO 8601 |
+
+## Links Fields
+
+| Links Field     | Type    | Description                                |
+|-----------------|---------|--------------------------------------------|
+| first           | String  | URL to the first page of results           |
+| prev            | String  | URL to the previous page of results        |
+| self            | String  | URL to the current page of results         |
+| next            | String  | URL to the next page of results            |
+| last            | String  | URL to the last page of results            |
+
+## Totals Fields
+
+| Links Field     | Type    | Description                                |
+|-----------------|---------|--------------------------------------------|
+| total_records   | Int     | The total number of results                |
+| total_pages     | Int     | The total number of pages of results       |
+
+## Pagination
+
+This API supports pagination returning 50 results per page. By default without
+any query parameters, the API defaults to page 1.
+
+Query different pages with the `?page=x` query parameter where `x` is a positive
+integer.
+
+If there is not a previous or next page of results, the `prev` and `next` URL's
+will be empty strings.
+
+
 
 ## Requirements
 

--- a/src/Controller/ContentFeed.php
+++ b/src/Controller/ContentFeed.php
@@ -39,7 +39,7 @@ class ContentFeed extends ControllerBase {
    */
   public function jsonResponse() {
 
-    $page = $this->requestStack->getCurrentRequest()->get('page');
+    $page = $this->requestStack->getCurrentRequest()->get('page') ?? 1;
 
     // Tests the query parameter to make sure we have a positive integer.
     $filter_options = [

--- a/src/Service/Sources.php
+++ b/src/Service/Sources.php
@@ -47,6 +47,13 @@ class Sources {
   protected $requestStack;
 
   /**
+   * Number of records per page.
+   *
+   * @var int
+   */
+  const RECORDS_PER_PAGE = 50;
+
+  /**
    * Retrieves and array of content for the AI feed.
    *
    * This method delivers all published nodes that are accessible to anonymous
@@ -57,19 +64,45 @@ class Sources {
    * @return array
    *   An array of content data for the AI feed.
    */
-  public function getContent(): array {
+  public function getContent($page = 1): array {
+
+    $jsonReturn = [
+      'data' => $this->getEntityData($page),
+      'links' => $this->getApiLinks($page),
+      'totals' => $this->getApiTotals(),
+    ];
+
+    return $jsonReturn;
+
+  }
+
+  /**
+   * Retrieves entity data.
+   *
+   * @param int $page
+   *   The current page to retrieve data from.
+   *
+   * @return array
+   *   An array of content data for the AI feed.
+   */
+  protected function getEntityData($page) {
+
     // Query to build a collection of content to be ingested.
+    $offset = ($page - 1) * self::RECORDS_PER_PAGE;
+
     $query = $this->entityTypeManager
       ->getStorage('node')
       ->getQuery()
       ->condition('status', NodeInterface::PUBLISHED)
+      ->range($offset, self::RECORDS_PER_PAGE)
       ->accessCheck(TRUE);
     $ids = $query->execute();
-    $entities = \Drupal\node\Entity\Node::loadMultiple($ids);
+    $entities = $this->entityTypeManager->getStorage('node')->loadMultiple($ids);
 
     // Process the collection to fit the shape of the API.
     $entityData = [];
     foreach ($entities as $entity) {
+      /** @var \Drupal\node\Entity\Node $entity */
       $entityData[] = [
         'id' => $this->getSearchIndexId($entity),
         'source' => 'drupal',
@@ -86,6 +119,74 @@ class Sources {
       ];
     }
     return $entityData;
+  }
+
+  /**
+   * Retrieves API links.
+   *
+   * @param int $page
+   *   The current page to calculate page links.
+   *
+   * @return array
+   *   An array of API links.
+   */
+  protected function getApiLinks($page) {
+    $host = $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost();
+    $baseUrl = "{$host}/api/ai/v1/content?page=";
+    $apiTotals = $this->getApiTotals($page);
+
+    $prevPageLink = "";
+    if ($apiTotals['total_pages'] > 1 && $page > 1 && $page <= $apiTotals['total_pages']) {
+      $prevPage = $page - 1;
+      $prevPageLink = $baseUrl . $prevPage;
+    }
+
+    $selfPageLink = "";
+    if ($page <= $apiTotals['total_pages']) {
+      $selfPageLink = $baseUrl . $page;
+    }
+
+    $nextPageLink = "";
+    if ($apiTotals['total_pages'] > 1 && $page < $apiTotals['total_pages']) {
+      $nextPage = $page + 1;
+      $nextPageLink = $baseUrl . $nextPage;
+    }
+
+    $apiLinks = [
+      'prev' => $prevPageLink,
+      'self' => $selfPageLink,
+      'next' => $nextPageLink,
+      'first' => $baseUrl . 1,
+      'last' => $baseUrl . $apiTotals['total_pages'],
+    ];
+
+    return $apiLinks;
+  }
+
+  /**
+   * Retrieves API totals.
+   *
+   * @return array
+   *   An array of API totals.
+   */
+  protected function getApiTotals() {
+    // Total entities.
+    $total = $this->entityTypeManager
+      ->getStorage('node')
+      ->getQuery()
+      ->condition('status', NodeInterface::PUBLISHED)
+      ->accessCheck(TRUE);
+    $ids = $total->execute();
+
+    $totalEntities = count($ids);
+    $totalPages = ceil($totalEntities / self::RECORDS_PER_PAGE);
+
+    $apiTotals = [
+      'total_records' => $totalEntities,
+      'total_pages' => $totalPages,
+    ];
+
+    return $apiTotals;
   }
 
   /**
@@ -117,7 +218,6 @@ class Sources {
     return $this->renderer->render($renderArray);
   }
 
-
   /**
    * Get a unique ID to reference this item in the search index.
    *
@@ -130,13 +230,13 @@ class Sources {
    *   A predictable and unique ID to reference this item in the search index.
    */
   public function getSearchIndexId(EntityInterface $entity) {
-    $host = \Drupal::request()->getHttpHost();
+    $host = $this->requestStack->getCurrentRequest()->getHttpHost();
     $host = preg_replace('/[^a-zA-Z0-9]+/', '-', $host);
     return $host . '-' . $entity->getEntityTypeId() . '-' . $entity->id();
   }
 
   /**
-   * Gets a standardizaed document type.
+   * Gets a standardized document type.
    *
    * Document type is the name of the Drupal entity and possible bundle.
    * Examples: "node/post", "media/image", or "user".

--- a/src/Service/Sources.php
+++ b/src/Service/Sources.php
@@ -58,7 +58,7 @@ class Sources {
    *
    * This method delivers all published nodes that are accessible to anonymous
    * users. In the future, this query can grow to include new filters and entity
-   * types. This method also processes the content to put it into a consistant
+   * types. This method also processes the content to put it into a consistent
    * and expected format.
    *
    * @return array
@@ -86,10 +86,10 @@ class Sources {
    *   An array of content data for the AI feed.
    */
   protected function getEntityData($page) {
-
-    // Query to build a collection of content to be ingested.
+    // Get offset of records based on page.
     $offset = ($page - 1) * self::RECORDS_PER_PAGE;
 
+    // Query to build a collection of content to be ingested.
     $query = $this->entityTypeManager
       ->getStorage('node')
       ->getQuery()
@@ -133,7 +133,7 @@ class Sources {
   protected function getApiLinks($page) {
     $host = $this->requestStack->getCurrentRequest()->getSchemeAndHttpHost();
     $baseUrl = "{$host}/api/ai/v1/content?page=";
-    $apiTotals = $this->getApiTotals($page);
+    $apiTotals = $this->getApiTotals();
 
     $prevPageLink = "";
     if ($apiTotals['total_pages'] > 1 && $page > 1 && $page <= $apiTotals['total_pages']) {
@@ -153,10 +153,10 @@ class Sources {
     }
 
     $apiLinks = [
+      'first' => $baseUrl . 1,
       'prev' => $prevPageLink,
       'self' => $selfPageLink,
       'next' => $nextPageLink,
-      'first' => $baseUrl . 1,
       'last' => $baseUrl . $apiTotals['total_pages'],
     ];
 


### PR DESCRIPTION
## [AYH-12: Pagination](https://github.com/orgs/yalesites-org/projects/3?pane=issue&itemId=50598345)

### Description of work
- Adds pagination to the AI Feed, 50 items per page
- Adds new `data`, `links`, and `totals` keys to the JSON output

### Functional testing steps:
- [ ] Load `/api/ai/v1/content` and verify that there are the 3 new keys listed above and that the `data` key contains the same records as before and that the results are capped at 50 per page.
- [ ] If there are more than 50 results, verify that the `links.next` URL exists
- [ ] Visit the `links.next` URL and verify that it contains the next grouping of results
- [ ] Test out `api/ai/v1/content?page=xyz` where `xyz` are different numbers, letters. Verify that if the page number isn't a positive integer, the results will default to page 1.
- [ ] Verify on the different pages that the `links` are correct - i.e. that on the last page of results, there is no `next` URL, on the first page of results there is no `prev` URL.
