### PR TITLE
AYH-9/10/11 - Add metadata to feed

### DIFF
--- a/ai_feed.info.yml
+++ b/ai_feed.info.yml
@@ -7,3 +7,5 @@ version: 1.0
 project: 'ai_feed'
 dependencies:
   - node:node
+  - metatag
+  - ai_metadata

--- a/ai_feed.services.yml
+++ b/ai_feed.services.yml
@@ -2,4 +2,4 @@ services:
   # Service to query and prepare content for the feed.
   ai_feed.sources:
     class: Drupal\ai_feed\Service\Sources
-    arguments: ['@entity_type.manager', '@logger.channel.default', '@renderer', '@request_stack']
+    arguments: ['@entity_type.manager', '@logger.channel.default', '@renderer', '@request_stack', '@metatag.manager', '@token']

--- a/ai_feed.services.yml
+++ b/ai_feed.services.yml
@@ -2,4 +2,4 @@ services:
   # Service to query and prepare content for the feed.
   ai_feed.sources:
     class: Drupal\ai_feed\Service\Sources
-    arguments: ['@entity_type.manager', '@logger.channel.default', '@renderer', '@request_stack', '@metatag.manager', '@token']
+    arguments: ['@entity_type.manager', '@logger.channel.default', '@renderer', '@request_stack', '@ai_metadata.manager']

--- a/src/Service/Sources.php
+++ b/src/Service/Sources.php
@@ -149,7 +149,7 @@ class Sources {
           'documentUrl' => $this->getUrl($entity),
           'documentTitle' => $entity->getTitle(),
           'documentContent' => $this->processContentBody($entity),
-          'metaTags' => '',
+          'metaTags' => $this->aiMetadataManager->getAiMetadata($entity)['ai_tags'],
           'metaDescription' => $this->aiMetadataManager->getAiMetadata($entity)['ai_description'],
           'dateCreated' => $this->formatTimestamp($entity->getCreatedTime()),
           'dateModified' => $this->formatTimestamp($entity->getChangedTime()),


### PR DESCRIPTION
## [AYH-9: Add metadata to Drupal feed](https://github.com/yalesites-org/ask-yale-health/issues/9)
## [AYH-10: Support content tagging](https://github.com/yalesites-org/ask-yale-health/issues/10)
## [AYH-11: Ingest tagging and metadata](https://github.com/yalesites-org/ask-yale-health/issues/11)

### Description of work
- Adds support for AI tagging and AI description coming from the `ai_metadata` module via metatags and inserts into the JSON feed

### Functional testing steps:
- [ ] This module now requires the `ai_metadata` module located here: https://github.com/yalesites-org/ai_metadata
- [ ] Once both modules are installed, visit a node edit page and expand the sidebar metatags (if this doesn't exist, you may need to add metatags as a field on the content type)
- [ ] Verify there is a new group outside of `Basic` and `Advanced` called `AI Metadata`
- [ ] Enter some text into either of the two new fields - AI Description and AI Tags. Ignore the "Disable" tag for now.
- [ ] Save the node
- [ ] Visit the feed at `/api/ai/v1/content` and find the node that you edited above
- [ ] Verify that the keys for `metaDescription` and `metaTags` are filled in with the data added above.
- [ ] Note: tokens work in these fields as well. Verify that by adding tokens, the data replaced from the token is correct. I.e. tags could come from a taxonomy reference field and will be a comma separated list of tags.
- [ ] Return to the node edit form
- [ ] Open the AI Metadata group under Metatags and select the "Disable indexing for AI feeds." and save the node
- [ ] Reload the API and verify that the node no longer exists in the feed. 
